### PR TITLE
Change Yom Kippur --> Purim

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Overall the DISC Unconference provided a fantastic venue for connecting with oth
   - Invite D&I speakers
   - Host D&I focused groups for meetups
   - Celebrate holidays and events for underrepresented minorities
-    - Black history month<sup>[[16](#r-16)]</sup>, gay pride, Yom Kippur
+    - Black history month<sup>[[16](#r-16)]</sup>, gay pride, Purim
   - Career fairs
   - Volunteer
   - Mentor


### PR DESCRIPTION
Yom Kippur isn't a good choice for a Jewish holiday to "celebrate" in the office, as it is a solemn, very religious holiday primarily based around meditating and penance for one's wrongs.  I give the alternative of Purim, which is a costume-and-carnival holiday.

(But it would be great practice to make sure Jewish employees have the opportunity to take Yom Kippur off, as if they are religious they are not supposed to work on this day.)